### PR TITLE
Add support for per-client Interface directory exports

### DIFF
--- a/export.lua
+++ b/export.lua
@@ -172,15 +172,10 @@ local GetFileList do
         if fileFilter[(name:match("%.(...)$") or ""):lower()] == fileType then
             path = path:gsub("[/\\]+", "/")
 
-            local shortPath = path
-            if filter ~= "all" then
-                shortPath = shortPath:gsub("[Ii][Nn][Tt][Ee][Rr][Ff][Aa][Cc][Ee]/", "")
-            end
             --print("CheckFile", path)
             files[#files + 1] = {
-                path = shortPath,
+                path = path,
                 id = id,
-                shortPath = shortPath .. name,
                 fullPath = path .. name,
             }
         end
@@ -199,7 +194,7 @@ local GetFileList do
 
             local fileData = assert(fileHandle:readFile("DBFilesClient/ManifestInterfaceData.db2"))
             for id, path, name in dbc.rows(fileData, "ss") do
-                if path:match("^[Ii][Nn][Tt][Ee][Rr][Ff][Aa][Cc][Ee][\\/]") then
+                if path:match("^[Ii][Nn][Tt][Ee][Rr][Ff][Aa][Cc][Ee][\\/_]") then
                     CheckFile(fileType, files, id, path, name)
                 end
             end
@@ -238,7 +233,7 @@ local CreateDirectories do
     function CreateDirectories(files, root)
         local dirs = {}
         for i = 1, #files do
-            local path = files[i].shortPath
+            local path = files[i].fullPath
             for endPoint in path:gmatch("()/") do
                 local subPath = path:sub(1, endPoint - 1)
                 local subLower = subPath:lower()
@@ -290,7 +285,7 @@ local ExtractFiles do
         for i = 1, #files do
             UpdateProgress(i / #files)
             file = files[i]
-            filePath = file.shortPath
+            filePath = file.fullPath
             fixedCase = (filePath:gsub("[^/]+()/", FixCase))
             w = fileHandle:readFile(file.fullPath)
             if w then


### PR DESCRIPTION
The upcoming 2.5.2 and 1.14.0 clients for BCC and Classic Era have merged together their interfaces somewhat and have a slightly altered directory structure as a result for code exports. It's _possible_ that we might also see similar changes in 9.1.5.

Previously all code would have been rooted under the "Interface/" tree, however with these new patches there are now three directories that need exporting:

  - Interface/
  - Interface_TBC/
  - Interface_Vanilla/

The ingame `exportinterfacefiles code` command exports all of these directories as of the most recent public build, including most notably an export of the "Vanilla" tree if run on the BCC client, and vice-versa for the "TBC" tree on Classic Era.

For the export tool to correctly export all the interface files going forward the following changes have been made:

  - Manifest filtering checks for paths matching either "^Interface/" or "^Interface_".
  - For filtered exports ("code" or "art") the shortening of paths to remove the top-level "Interface" directory has been removed.

The path shortening change is required since, if we attempted to merge the three interface directories, we'd run into issues with duplicate filenames - for example "SharedXML/Utils.lua" exists in both the "Interface_TBC" and "Interface_Vanilla" trees with different contents.

Note that as a result you'll probably need to adjust the workflows on wow-ui-source and wow-ui-textures to accommodate the fact that there's now an `./Interface{,_TBC,_Vanilla}/{Frame,Glue,LCD,Shared}XML/` directory structure being exported by this tool instead of `./{Frame,Glue,LCD,Shared}XML`.