### PR TITLE
Hack in WDC4 "support"

### DIFF
--- a/export.lua
+++ b/export.lua
@@ -212,6 +212,7 @@ local GetFileList do
             fileHandle.root:addFileIDPaths(FILEID_PATH_MAP)
 
             local fileData = assert(fileHandle:readFile("DBFilesClient/ManifestInterfaceData.db2"))
+            fileData = fileData:gsub("^WDC4", "WDC3")
             for id, path, name in dbc.rows(fileData, "ss") do
                 if path:match("^[Ii][Nn][Tt][Ee][Rr][Ff][Aa][Cc][Ee][\\/_]") then
                     CheckFile(fileType, files, id, path, name)


### PR DESCRIPTION
The luadbc library hasn't been updated for WDC4 support and both patch 10.1.0 and the upcoming 3.4.2 PTR are using the new database format. For every 10.1.0 build so far I've been having to do manual exports of the interface code and committing them to the UI source repo, which is starting to get a bit tiresome.

For the use cases required by the interface export tool, we can work around the lack of proper WDC4 support by just altering the magic header to claim the file is WDC3 instead. This is of course a hack, but in practice it works well enough for now and allows automated extraction of the interface to function once more. If luadbc is ever updated to support WDC4 the hack can be removed.