### PR TITLE
Update casc/dbc libraries to latest versions

### DIFF
--- a/export.lua
+++ b/export.lua
@@ -213,7 +213,6 @@ local GetFileList do
             fileHandle.root:addFileIDPaths(FILEID_PATH_MAP)
 
             local fileData = assert(fileHandle:readFile("DBFilesClient/ManifestInterfaceData.db2"))
-            fileData = fileData:gsub("^WDC4", "WDC3")
             for id, path, name in dbc.rows(fileData, "ss") do
                 if path:match("^[Ii][Nn][Tt][Ee][Rr][Ff][Aa][Cc][Ee][\\/_]") then
                     CheckFile(fileType, files, id, path, name)

--- a/libs/casc/bin.c
+++ b/libs/casc/bin.c
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/> */
+/* SPDX-License-Identifier: Artistic-2.0 */
+
 #include <lua.h>
 #include <lauxlib.h>
 

--- a/libs/casc/bin.lua
+++ b/libs/casc/bin.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, sbyte, schar, sgsub, sformat, ssub = {}, string.byte, string.char, string.gsub, string.format, string.sub
 local inf, nan, floor, min = math.huge, math.huge-math.huge, math.floor, math.min
 local MAX_SLICE_SIZE = 4096

--- a/libs/casc/blte.lua
+++ b/libs/casc/blte.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, plat, bin = {}, require("casc.platform"), require("casc.bin")
 local uint32_le, uint32_be, decompress = bin.uint32_le, bin.uint32_be, plat.decompress
 

--- a/libs/casc/bspatch.lua
+++ b/libs/casc/bspatch.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, decompress, bin = {}, require("casc.platform").decompress, require("casc.bin")
 local CONCAT_CHUNK_SIZE, CONCAT_STOP_LENGTH = 512, 16384
 

--- a/libs/casc/encoding.lua
+++ b/libs/casc/encoding.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, bin = {}, require("casc.bin")
 local uint32_be, uint16_le, ssub = bin.uint32_be, bin.uint16_le, string.sub
 

--- a/libs/casc/install.lua
+++ b/libs/casc/install.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, bin = {}, require("casc.bin")
 local byte = string.byte
 

--- a/libs/casc/jenkins96.lua
+++ b/libs/casc/jenkins96.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, plat, bin = {}, require("casc.platform"), require("casc.bin")
 
 local rot, xor, uint32_le, to_le32 = plat.rol, plat.bxor, bin.uint32_le, bin.to_le32

--- a/libs/casc/md5.lua
+++ b/libs/casc/md5.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, bit = {}, require("casc.platform")
 local bxor, band, bor, rol, bnot = bit.bxor, bit.band, bit.bor, bit.rol, bit.bnot
 local schar, sbyte, floor = string.char, string.byte, math.floor

--- a/libs/casc/ribbit.lua
+++ b/libs/casc/ribbit.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/casc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M = {}
 local plat = require("casc.platform")
 

--- a/libs/dbc/bin.lua
+++ b/libs/dbc/bin.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: © 2023 foxlit <https://www.townlong-yak.com/dbc/>
+-- SPDX-License-Identifier: Artistic-2.0
+
 local M, sbyte = {}, string.byte
 local inf, nan = math.huge, math.huge-math.huge
 
@@ -74,6 +77,17 @@ end
 function M.int32_le(s, pos)
 	local a, b, c, d = sbyte(s, (pos or 0)+1, (pos or 0) + 4)
 	return (d or 0)*256^3 + (c or 0)*256^2 + (b or 0)*256 + a - (d > 127 and 2^32 or 0)
+end
+
+function M.u32_float(u)
+	local a,b,c,d = u % 256, u % 65536, u % 16777216, u % 4294967296
+	b, c, d = (b-a)/256, (c-b)/65536, (d-c)/16777216
+	local s, e, f = d > 127 and -1 or 1, (d % 128)*2 + (c > 127 and 1 or 0), a + b*256 + (c % 128)*256^2
+	if e > 0 and e < 255 then
+		return s * (1+f/2^23) * 2^(e-127)
+	else
+		return e == 0 and (s * f/2^23 * 2^-126) or f == 0 and (s * inf) or nan
+	end
 end
 
 return M


### PR DESCRIPTION
Patch 10.1.7 brings about breaking changes to the root manifest that's processed by LuaCASC, necessitating an update for this tool to continue working.

LuaDBC has received an update as well to properly support the WDC4 database type, so that is included. With this the hack of substituting the header of database files can be removed.

Library updates appear to be fully backwards compatible, at least insofar as I ran into no issues exporting interface files locally as a quick test.