### PR TITLE
Support textual manifests

### DIFF
--- a/export.lua
+++ b/export.lua
@@ -70,7 +70,7 @@ filter = filter or "all"
 write("Extracting %s from %s %s...", filter, project, branch)
 local product = projects[project] .. branches[branch]
 
-package.path = ";;./InterfaceExport/libs/?.lua;./InterfaceExport/libs/?/init.lua"
+package.path = package.path .. ";libs/?.lua;libs/?/init.lua;InterfaceExport/libs/?.lua;InterfaceExport/libs/?/init.lua"
 local casc = require("casc")
 local plat = require("casc.platform")
 local dbc = require("dbc")


### PR DESCRIPTION
In 1.15.4, 4.4.1, and 11.0.5 Blizzard appear to be moving toward deprecating and perhaps removing the manifest database used for exports.

Instead, there's a trio of line-delimited text files shipped in the data for both of these clients. The `exportinterfacefiles code` command has been hooked up to read these instead of the manifest, and exports whatever is named inside of them - an example of one such file can [be found here](https://wago.tools/api/casc/6067013?download).

At present this support is limited to just code exports; art assets for now at least are continuing to use the old manifest database.

This changeset teaches the export script how to process text manifests. If we're explicitly dumping the code for a product branch, we'll test if the build contains one of the required txt files and - if so - will read the full list of files from that _instead_ of consulting the manifest database. If the file isn't found, then we'll use the old manifest logic.

Note that for now this only works for explicit code exports - dumping all interface files won't trigger the manifest path for now. Would rather wait and see what Blizzard do for art before worrying about that case.

One extra bit of good news is that the txt files provided by Blizzard appear to be pre-sanitized and omit files that aren't part of public client builds, so we'll no longer have stray empty directories once the export has concluded.